### PR TITLE
Add ability to access the inner Crossbeam channel

### DIFF
--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -19,6 +19,11 @@ impl<T> Receiver<T> {
             pending: None,
         }
     }
+
+    pub fn clone_inner(&self) -> crossbeam_channel::Receiver<T> {
+        self.inner.clone()
+    }
+
 }
 
 impl<T: Send + 'static> Stream for Receiver<T> {

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -20,8 +20,8 @@ impl<T> Receiver<T> {
         }
     }
 
-    pub fn into_inner(&self) -> &crossbeam_channel::Receiver<T> {
-        &self.inner
+    pub fn into_inner(self) -> crossbeam_channel::Receiver<T> {
+        self.inner
     }
 
 }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -20,8 +20,8 @@ impl<T> Receiver<T> {
         }
     }
 
-    pub fn clone_inner(&self) -> crossbeam_channel::Receiver<T> {
-        self.inner.clone()
+    pub fn into_inner(&self) -> &crossbeam_channel::Receiver<T> {
+        &self.inner
     }
 
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -40,6 +40,10 @@ impl<T> Sender<T> {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
+
+    pub fn clone_inner(&self) -> crossbeam_channel::Sender<T> {
+        self.inner.clone()
+    }
 }
 
 impl<T> Clone for Sender<T> {

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -41,8 +41,8 @@ impl<T> Sender<T> {
         self.inner.len()
     }
 
-    pub fn into_inner(&self) -> &crossbeam_channel::Sender<T> {
-        &self.inner
+    pub fn into_inner(self) -> crossbeam_channel::Sender<T> {
+        self.inner
     }
 }
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -41,8 +41,8 @@ impl<T> Sender<T> {
         self.inner.len()
     }
 
-    pub fn clone_inner(&self) -> crossbeam_channel::Sender<T> {
-        self.inner.clone()
+    pub fn into_inner(&self) -> &crossbeam_channel::Sender<T> {
+        &self.inner
     }
 }
 


### PR DESCRIPTION
The rationale here is:

1. It can be useful to use something like `try_recv` or other methods that channel-async doesn't expose even from async code.
2. It's possible to use the same Crossbeam channel from async and non-async code.

I haven't made many PRs so if I've broken any etiquette, please forgive me. Constructive criticism is welcome.